### PR TITLE
feat: :zap: use partial reloads

### DIFF
--- a/app/javascript/features/projects/category/Categories.tsx
+++ b/app/javascript/features/projects/category/Categories.tsx
@@ -77,7 +77,14 @@ const Categories: FC<Props> = ({ items }) => {
       // If any changes in filter values, then request for information
       if (!deepEqual(prevValues, values)) {
         const query = values.category ? { category: values.category } : {};
-        Inertia.get('projects', query as RequestPayload, {
+        // This works too, but we want partial loads, to fetch required information due to side effects.
+        // Inertia.get('projects', query as RequestPayload, {
+        //   replace: true,
+        //   preserveState: true,
+        // });
+        Inertia.reload({
+          only: ['projects'],
+          data: query as RequestPayload,
           replace: true,
           preserveState: true,
         });


### PR DESCRIPTION
## Description
Reduce latency, in applying category filters. Won't re-fetch categories
- [x] Use partial reloads from inertia utils, to fetch required information
- [x] The Inertia.reload, will fetch the requested information, here its is projects.


<!-- Describe feature or change -->

## How this has been tested

- [ ] Unit tests
- [ ] E2E Tests
- [ ] Integration Tests
- [x] Manually Tested

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
